### PR TITLE
Allowing code-sniffer warnings on build. 

### DIFF
--- a/build/phing/build.xml
+++ b/build/phing/build.xml
@@ -89,7 +89,7 @@
                 standard="${repo.root}/vendor/drupal/coder/coder_sniffer/Drupal/"
                 showWarnings="true"
                 haltonerror="true"
-                haltonwarning="true">
+                haltonwarning="false">
             <fileset refid="custom.files"/>
             <formatter type="full" usefile="false"/>
         </phpcodesniffer>


### PR DESCRIPTION
DCS was complaining about legitimate comments that exceeded 80 chars.  See https://www.drupal.org/node/2530920 for more information.
