### PR TITLE
Manual Cloudflare Invalidator 

### DIFF
--- a/cloudflare.links.task.yml
+++ b/cloudflare.links.task.yml
@@ -3,12 +3,6 @@ cloudflare.admin_settings_form:
   route_name: cloudflare.admin_settings_form
   base_route: cloudflare.admin_settings_form
 
-cloudflare.admin_settings_form.cache_clear:
-  title: 'Cache Clearing'
-  route_name: cloudflare.cache_clear_form
-  base_route: cloudflare.admin_settings_form
-  weight: 10
-
 cloudflare.admin_settings_form.admin_zone:
   title: 'Zone Settings'
   route_name: cloudflare.zone_form

--- a/cloudflare.routing.yml
+++ b/cloudflare.routing.yml
@@ -1,6 +1,6 @@
 cloudflare.admin_settings_form:
-  path: '/admin/config/development/cloudflare'
-  parent: system.admin_config_development
+  path: '/admin/config/services/cloudflare'
+  parent: system.admin_config_services
   defaults:
     _form: '\Drupal\cloudflare\Form\CloudFlareAdminSettingsForm'
     _title: 'CloudFlare API Credentials'
@@ -8,8 +8,8 @@ cloudflare.admin_settings_form:
     _permission: 'access administration pages'
 
 cloudflare.zone_form:
-  path: '/admin/config/development/cloudflare/zone'
-  parent: system.admin_config_development.cloudflare.admin_settings_form
+  path: '/admin/config/services/cloudflare/zone'
+  parent: system.admin_config_services.cloudflare.admin_settings_form
   defaults:
     _form: '\Drupal\cloudflare\Form\CloudFlareZoneForm'
     _title: 'CloudFlare Zone Settings'

--- a/cloudflare.routing.yml
+++ b/cloudflare.routing.yml
@@ -16,15 +16,6 @@ cloudflare.zone_form:
   requirements:
     _permission: 'access administration pages'
 
-cloudflare.cache_clear_form:
-  path: '/admin/config/development/cloudflare/cache-clear'
-  parent: system.admin_config_development.cloudflare.admin_settings_form
-  defaults:
-    _form: '\Drupal\cloudflare\Form\CloudFlareCacheClearForm'
-    _title: 'CloudFlare Cache Clear'
-  requirements:
-    _permission: 'access administration pages'
-
 
 
 

--- a/modules/cloudflaremanualinvalidator/README.md
+++ b/modules/cloudflaremanualinvalidator/README.md
@@ -1,0 +1,3 @@
+## Introduction
+This tool is a fallback in the event that automatic purging does not work.  
+In theory this should be unnecessary.  

--- a/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.info.yml
+++ b/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.info.yml
@@ -1,0 +1,11 @@
+name: CloudFlareManualInvalidator
+type: module
+description: Allows manual cache clears of cloudflare.
+core: 8.x
+package: Web services
+configure: cloudflare.admin_settings_form
+
+dependencies:
+  - composer_manager
+  - cloudflare
+

--- a/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.links.task.yml
+++ b/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.links.task.yml
@@ -1,0 +1,5 @@
+cloudflare.admin_settings_form.cache_clear:
+  title: 'Cache Clearing'
+  route_name: cloudflare.cache_clear_form
+  base_route: cloudflare.admin_settings_form
+  weight: 10

--- a/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.module
+++ b/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.module
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * @file
+ * Contains cloudflaremanualinvalidator.module.
+ */
+
+use Drupal\Core\Routing\RouteMatchInterface;
+
+/**
+ * Implements hook_help().
+ */
+function cloudflaremanualinvalidator_help($route_name, RouteMatchInterface $route_match) {
+  switch ($route_name) {
+    // Main module help for the cloudflare invalidation module.
+    case 'help.page.cloudflare':
+      $output = '';
+      $output .= '<h3>' . t('About') . '</h3>';
+      $output .= '<p>' . t('CloudFlare CDN integration.') . '</p>';
+      return $output;
+
+    default:
+  }
+}

--- a/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.routing.yml
+++ b/modules/cloudflaremanualinvalidator/cloudflaremanualinvalidator.routing.yml
@@ -1,0 +1,9 @@
+cloudflare.cache_clear_form:
+  path: '/admin/config/services/cloudflare/cache-clear'
+  parent: system.admin_config_services.cloudflare.admin_settings_form
+  defaults:
+    _form: '\Drupal\cloudflaremanualinvalidator\Form\CloudFlareCacheClearForm'
+    _title: 'CloudFlare Cache Clear'
+  requirements:
+    _permission: 'access administration pages'
+

--- a/modules/cloudflaremanualinvalidator/src/Form/CloudFlareCacheClearForm.php
+++ b/modules/cloudflaremanualinvalidator/src/Form/CloudFlareCacheClearForm.php
@@ -2,10 +2,10 @@
 
 /**
  * @file
- * Contains Drupal\cloudflare\Form\DefaultForm.
+ * Contains Drupal\cloudflaremanualinvalidator\Form\CloudFlareCacheClearForm.
  */
 
-namespace Drupal\cloudflare\Form;
+namespace Drupal\cloudflaremanualinvalidator\Form;
 
 use CloudFlarePhpSdk\ApiEndpoints\ZoneApi;
 use CloudFlarePhpSdk\Exceptions\CloudFlareHttpException;


### PR DESCRIPTION
Moved the manual cache clearing UI. Based on discussion it seems that we should not need the manual UI under normal circumstances.  This is still being provided in an optional module as a fallback in case things don't quite work as anticipated for end users.  

In response to @wimleers 's PR:
https://github.com/d8-contrib-modules/cloudflare/pull/15
