### PR TITLE
Return the correct client IP 

### DIFF
--- a/cloudflare.links.task.yml
+++ b/cloudflare.links.task.yml
@@ -1,5 +1,5 @@
 cloudflare.admin_settings_form:
-  title: 'API Credentials'
+  title: 'Config'
   route_name: cloudflare.admin_settings_form
   base_route: cloudflare.admin_settings_form
 

--- a/cloudflare.services.yml
+++ b/cloudflare.services.yml
@@ -11,3 +11,8 @@ services:
     arguments: ['%cloudflare.cache_tag_header_limit%']
     tags:
       - { name: event_subscriber }
+
+  cloudflare.boot:
+    class: Drupal\cloudflare\EventSubscriber\CloudFlareBoot
+    tags:
+      - { name: event_subscriber }

--- a/src/EventSubscriber/CloudFlareBoot.php
+++ b/src/EventSubscriber/CloudFlareBoot.php
@@ -1,0 +1,88 @@
+<?php
+namespace Drupal\cloudflare\EventSubscriber;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Drupal\Core\Cache\Cache;
+
+/**
+ * Provides a CloudFlareBoot.
+ */
+class CloudFlareBoot implements EventSubscriberInterface {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  static function getSubscribedEvents() {
+    $events[KernelEvents::REQUEST][] = array('CloudFlareLoad', 20);
+    return $events;
+  }
+
+  public function CloudFlareLoad(GetResponseEvent $event) {
+    $reverse_proxy_header = $event->getRequest()
+      ->getTrustedHeaderName(Request::HEADER_CLIENT_IP);
+    $forwarded = $event->getRequest()->headers->get($reverse_proxy_header);
+    $clientIps = array_map('trim', explode(',', $forwarded));
+
+    $trustedProxies = $event->getRequest()->getTrustedProxies();
+
+    foreach ($clientIps as $ip) {
+      if (!in_array($ip, $trustedProxies) && $this->cloudflare_ip_address_in_range($ip)) {
+        $trustedProxies[] = $ip;
+      }
+    }
+    $event->getRequest()->setTrustedProxies($trustedProxies);
+  }
+
+
+  function cloudflare_ip_address_in_range($checkip, $range = FALSE) {
+    if (!$range) {
+      $range = $this->cloudflare_ip_ranges();
+    }
+    if (is_array($range)) {
+      foreach ($range as $ip_range) {
+        if ($this->cloudflare_ip_address_in_range($checkip, $ip_range)) {
+          return TRUE;
+        }
+      }
+      return FALSE;
+    }
+
+    @list($ip, $len) = explode('/', $range);
+
+    if (($min = ip2long($ip)) !== FALSE && !is_null($len)) {
+      $clong = ip2long($checkip);
+      $max = ($min | (1 << (32 - $len)) - 1);
+      if ($clong > $min && $clong < $max) {
+        return TRUE;
+      }
+      else {
+        return FALSE;
+      }
+    }
+  }
+
+  /**
+   * Get a list of cloudflare IP Ranges
+   */
+  function cloudflare_ip_ranges() {
+    if ($cache = \Drupal::cache()->get('cloudflare_ip_ranges')) {
+      return $cache->data;
+    }
+    else {
+      $ip_blocks = file_get_contents("https://www.cloudflare.com/ips-v4");
+      $cloudflare_ips = explode("\n", $ip_blocks);
+      $cloudflare_ips = array_map('trim', $cloudflare_ips);
+
+      \Drupal::cache()
+        ->set('cloudflare_ip_ranges', $cloudflare_ips, Cache::PERMANENT);
+      return $cloudflare_ips;
+    }
+  }
+
+}
+
+?>

--- a/src/EventSubscriber/CloudFlareBoot.php
+++ b/src/EventSubscriber/CloudFlareBoot.php
@@ -7,12 +7,12 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Drupal\Core\Cache\Cache;
 
+define('CLOUDFLARE_URL_IPV4_RANGE', 'https://www.cloudflare.com/ips-v4');
+
 /**
  * Provides a CloudFlareBoot.
  */
 class CloudFlareBoot implements EventSubscriberInterface {
-
-
   /**
    * {@inheritdoc}
    */
@@ -73,7 +73,7 @@ class CloudFlareBoot implements EventSubscriberInterface {
       return $cache->data;
     }
     else {
-      $ip_blocks = file_get_contents("https://www.cloudflare.com/ips-v4");
+      $ip_blocks = file_get_contents(CLOUDFLARE_URL_IPV4_RANGE);
       $cloudflare_ips = explode("\n", $ip_blocks);
       $cloudflare_ips = array_map('trim', $cloudflare_ips);
 


### PR DESCRIPTION
Drupal has got the function Drupal::request()->getClientIp().
I made a class that behaves like the hook_boot. This class is called in every request.
I added Cloudflare IPs in a trusted proxies list. This way, Drupal Core can return the client ip instead of CloudFlare IP.
